### PR TITLE
Camera lifecycle tweaks

### DIFF
--- a/app/src/main/java/co/krypt/kryptonite/onboarding/FirstPairFragment.java
+++ b/app/src/main/java/co/krypt/kryptonite/onboarding/FirstPairFragment.java
@@ -62,10 +62,21 @@ public class FirstPairFragment extends Fragment {
     }
 
     @Override
+    public void onResume() {
+        super.onResume();
+        pairFragment.setUserVisibleHint(true);
+    }
+
+    @Override
+    public void onPause() {
+        pairFragment.setUserVisibleHint(false);
+        super.onPause();
+    }
+
+    @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         getChildFragmentManager().beginTransaction().add(R.id.pairLayout, pairFragment).commit();
-        pairFragment.setUserVisibleHint(true);
 
         View root = inflater.inflate(R.layout.fragment_first_pair, container, false);
         Button nextButton = (Button) root.findViewById(R.id.nextButton);

--- a/app/src/main/java/co/krypt/kryptonite/pairing/PairFragment.java
+++ b/app/src/main/java/co/krypt/kryptonite/pairing/PairFragment.java
@@ -297,7 +297,6 @@ public class PairFragment extends Fragment implements PairDialogFragment.PairLis
             Log.v(TAG, "stopping camera");
             mCamera.stopPreview();
             mCamera.setPreviewCallback(null);
-            mCamera.unlock();
             mCamera.release();
             mCamera = null;
         }


### PR DESCRIPTION
The refactor looks good!

The camera wasn't being started within the FirstPairFragment, so I added a visibility hint call to its initialization.

Also calling `camera.unlock()` seemed to keep the camera active even after the app was paused (tested by not being able to toggle the flashlight).

Once these changes are in we should be able to merge your PR :)

Since we haven't yet figured out the licensing of Kryptonite, we have to ask that you agree to and add the following in each of your commit messages:
```
I agree to license all rights to my contributions in each modified file exclusively to KryptCo, Inc.
```

Thanks again and let us know if you have any questions!
